### PR TITLE
Add FastAPI API and static dashboard for agent platform

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,71 @@
+# Dynamic Agent Platform Backend
+
+This package exposes the core services for the dynamic agent platform and now ships with a FastAPI-powered HTTP surface for local development. It covers:
+
+1. **Registry management** for agent templates, tools, functions, and deployed instances backed by SQLite.
+2. **Dynamic generation stubs** that simulate GPT-driven component creation so the self-improvement loop can run offline.
+3. **Orchestration workflows** that deploy agents, route requests using simple heuristics, and register self-improvement proposals.
+4. **REST API** for the frontend experience with CORS enabled out of the box.
+
+## Quickstart
+
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[dev]
+```
+
+### Run the API server
+
+```bash
+cd backend
+python -m app.main
+# or using uvicorn directly
+uvicorn app.api:app --reload
+```
+
+The `python -m app.main` entry point seeds a small dataset, prints the created records, and then serves the API at <http://localhost:8000>.
+
+## Example Requests
+
+```bash
+curl -X POST http://localhost:8000/templates \
+  -H "Content-Type: application/json" \
+  -d '{
+        "name": "ResearchAssistant",
+        "description": "Helps summarize papers",
+        "required_tools": [],
+        "model_config": {"temperature": 0.3}
+      }'
+
+curl http://localhost:8000/templates
+
+curl -X POST http://localhost:8000/agents/deploy \
+  -H "Content-Type: application/json" \
+  -d '{
+        "template_id": 1,
+        "name": "Researcher",
+        "owner_id": "demo"
+      }'
+```
+
+## Running Tests
+
+```bash
+cd backend
+pytest
+```
+
+## Module Overview
+
+- `app/database.py` – SQLite connection manager and schema bootstrapper.
+- `app/models.py` – Dataclasses describing registry records.
+- `app/registry.py` – CRUD operations and query helpers built on the database module.
+- `app/dynamic.py` – Offline dynamic component generator for tests and prototyping.
+- `app/orchestration.py` – Deployment, routing, and self-improvement services.
+- `app/api.py` – FastAPI application exposing registry, routing, and improvement endpoints.
+- `app/main.py` – CLI launcher that seeds demo data and starts the API server.
+- `tests/` – Unit tests covering registry flows, orchestration, dynamic generation, and HTTP endpoints.
+
+See `../frontend/README.md` for details on the accompanying web interface.

--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -1,0 +1,185 @@
+"""HTTP API surface for the dynamic agent platform backend."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import Depends, FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+
+from .dynamic import DynamicBuilder
+from .orchestration import OrchestrationEngine, RouteResult
+from .registry import RegistryService
+from .schemas import (
+    AgentDeployRequest,
+    AgentDeployResponse,
+    AgentRead,
+    RouteRequest,
+    RouteResponse,
+    SelfImproveResponse,
+    TemplateCreate,
+    TemplateRead,
+    ToolCreate,
+    ToolRead,
+    FunctionCreate,
+    FunctionRead,
+)
+
+
+class Application:
+    """Container for shared services and the FastAPI instance."""
+
+    def __init__(self, registry: RegistryService | None = None) -> None:
+        self.registry = registry or RegistryService()
+        self.builder = DynamicBuilder(registry=self.registry)
+        self.engine = OrchestrationEngine(registry=self.registry, builder=self.builder)
+        self.api = self._create_api()
+
+    # ------------------------------------------------------------------
+    # Service layer helpers (used by tests and CLI tooling)
+    # ------------------------------------------------------------------
+    def create_template(self, **kwargs: Any):
+        return self.registry.create_agent_template(**kwargs)
+
+    def list_templates(self):
+        return self.registry.list_agent_templates()
+
+    def create_tool(self, **kwargs: Any):
+        return self.registry.create_tool(**kwargs)
+
+    def list_tools(self):
+        return self.registry.list_tools()
+
+    def create_function(self, **kwargs: Any):
+        return self.registry.create_function(**kwargs)
+
+    def list_functions(self):
+        return self.registry.list_functions()
+
+    def list_agents(self, owner_id: str | None = None):
+        return self.registry.list_agent_instances(owner_id=owner_id)
+
+    def deploy_agent(self, **kwargs: Any) -> int:
+        return self.engine.deploy_agent(**kwargs)
+
+    def route_request(self, *, user_input: str, owner_id: str | None = None) -> RouteResult:
+        return self.engine.route_request(user_input=user_input, owner_id=owner_id)
+
+    async def self_improve(self, owner_id: str | None = None) -> dict[str, Any]:
+        return await self.engine.self_improve(owner_id=owner_id)
+
+    # ------------------------------------------------------------------
+    # FastAPI setup
+    # ------------------------------------------------------------------
+    def _create_api(self) -> FastAPI:
+        app = FastAPI(title="Dynamic Agent Platform", version="0.1.0")
+
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=["*"],
+            allow_credentials=True,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+
+        def get_registry() -> RegistryService:
+            return self.registry
+
+        def get_engine() -> OrchestrationEngine:
+            return self.engine
+
+        @app.get("/health")
+        def health() -> dict[str, str]:
+            return {"status": "ok"}
+
+        @app.post("/templates", response_model=TemplateRead, status_code=201)
+        def create_template_endpoint(
+            payload: TemplateCreate,
+            registry: RegistryService = Depends(get_registry),
+        ) -> TemplateRead:
+            template = registry.create_agent_template(**payload.model_dump())
+            return TemplateRead.model_validate(template)
+
+        @app.get("/templates", response_model=list[TemplateRead])
+        def list_templates_endpoint(
+            registry: RegistryService = Depends(get_registry),
+        ) -> list[TemplateRead]:
+            return [TemplateRead.model_validate(item) for item in registry.list_agent_templates()]
+
+        @app.post("/tools", response_model=ToolRead, status_code=201)
+        def create_tool_endpoint(
+            payload: ToolCreate,
+            registry: RegistryService = Depends(get_registry),
+        ) -> ToolRead:
+            tool = registry.create_tool(**payload.model_dump())
+            return ToolRead.model_validate(tool)
+
+        @app.get("/tools", response_model=list[ToolRead])
+        def list_tools_endpoint(
+            registry: RegistryService = Depends(get_registry),
+        ) -> list[ToolRead]:
+            return [ToolRead.model_validate(item) for item in registry.list_tools()]
+
+        @app.post("/functions", response_model=FunctionRead, status_code=201)
+        def create_function_endpoint(
+            payload: FunctionCreate,
+            registry: RegistryService = Depends(get_registry),
+        ) -> FunctionRead:
+            function = registry.create_function(**payload.model_dump())
+            return FunctionRead.model_validate(function)
+
+        @app.get("/functions", response_model=list[FunctionRead])
+        def list_functions_endpoint(
+            registry: RegistryService = Depends(get_registry),
+        ) -> list[FunctionRead]:
+            return [FunctionRead.model_validate(item) for item in registry.list_functions()]
+
+        @app.get("/agents", response_model=list[AgentRead])
+        def list_agents_endpoint(
+            owner_id: str | None = None,
+            registry: RegistryService = Depends(get_registry),
+        ) -> list[AgentRead]:
+            agents = registry.list_agent_instances(owner_id=owner_id)
+            return [AgentRead.model_validate(agent) for agent in agents]
+
+        @app.post("/agents/deploy", response_model=AgentDeployResponse, status_code=201)
+        def deploy_agent_endpoint(
+            payload: AgentDeployRequest,
+            registry: RegistryService = Depends(get_registry),
+            engine: OrchestrationEngine = Depends(get_engine),
+        ) -> AgentDeployResponse:
+            instance_id = engine.deploy_agent(**payload.model_dump())
+            instance = registry.get_agent_instance(instance_id)
+            if instance is None:  # pragma: no cover - defensive guard
+                raise HTTPException(status_code=500, detail="Agent deployment failed")
+            return AgentDeployResponse.model_validate(instance)
+
+        @app.post("/route", response_model=RouteResponse)
+        def route_endpoint(
+            payload: RouteRequest,
+            engine: OrchestrationEngine = Depends(get_engine),
+        ) -> RouteResponse:
+            try:
+                result = engine.route_request(
+                    user_input=payload.user_input,
+                    owner_id=payload.owner_id,
+                )
+            except ValueError as exc:  # no available agent
+                raise HTTPException(status_code=404, detail=str(exc)) from exc
+            return RouteResponse.model_validate(result)
+
+        @app.post("/self-improve", response_model=SelfImproveResponse)
+        async def self_improve_endpoint(
+            owner_id: str | None = None,
+            engine: OrchestrationEngine = Depends(get_engine),
+        ) -> SelfImproveResponse:
+            result = await engine.self_improve(owner_id=owner_id)
+            return SelfImproveResponse.model_validate(result)
+
+        return app
+
+
+application = Application()
+app = application.api
+
+__all__ = ["Application", "app", "application"]

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,122 @@
+"""SQLite helpers for the dynamic agent platform backend."""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+DEFAULT_DB_PATH = Path(__file__).resolve().parent.parent / "data" / "agent_platform.db"
+
+
+class Database:
+    """Small wrapper around sqlite3 with automatic schema creation."""
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        self.path = Path(path) if path else DEFAULT_DB_PATH
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._ensure_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    @contextmanager
+    def session(self) -> Iterator[sqlite3.Connection]:
+        conn = self._connect()
+        try:
+            yield conn
+            conn.commit()
+        except Exception:  # pragma: no cover - defensive rollback path
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def _ensure_schema(self) -> None:
+        with self.session() as conn:
+            conn.executescript(
+                """
+                PRAGMA foreign_keys = ON;
+
+                CREATE TABLE IF NOT EXISTS agent_templates (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT UNIQUE NOT NULL,
+                    category TEXT DEFAULT 'general',
+                    description TEXT NOT NULL,
+                    instructions_template TEXT DEFAULT '',
+                    model_config TEXT DEFAULT '{}',
+                    required_tools TEXT DEFAULT '[]',
+                    sample_interactions TEXT DEFAULT '[]',
+                    performance_metrics TEXT DEFAULT '{}',
+                    created_by TEXT DEFAULT 'system',
+                    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                    version INTEGER DEFAULT 1
+                );
+
+                CREATE TABLE IF NOT EXISTS tool_registry (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT UNIQUE NOT NULL,
+                    category TEXT DEFAULT 'general',
+                    description TEXT NOT NULL,
+                    input_schema TEXT DEFAULT '{}',
+                    implementation_code TEXT DEFAULT '',
+                    dependencies TEXT DEFAULT '[]',
+                    test_cases TEXT DEFAULT '[]',
+                    performance_data TEXT DEFAULT '{}',
+                    created_by TEXT DEFAULT 'system',
+                    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                    version INTEGER DEFAULT 1
+                );
+
+                CREATE TABLE IF NOT EXISTS function_registry (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT UNIQUE NOT NULL,
+                    category TEXT DEFAULT 'general',
+                    description TEXT NOT NULL,
+                    parameters_schema TEXT DEFAULT '{}',
+                    implementation_code TEXT DEFAULT '',
+                    dependencies TEXT DEFAULT '[]',
+                    test_cases TEXT DEFAULT '[]',
+                    created_by TEXT DEFAULT 'system',
+                    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                    version INTEGER DEFAULT 1
+                );
+
+                CREATE TABLE IF NOT EXISTS agent_instances (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT UNIQUE NOT NULL,
+                    template_id INTEGER NOT NULL REFERENCES agent_templates(id) ON DELETE CASCADE,
+                    custom_instructions TEXT DEFAULT '',
+                    assigned_tools TEXT DEFAULT '[]',
+                    assigned_functions TEXT DEFAULT '[]',
+                    status TEXT DEFAULT 'active',
+                    owner_id TEXT,
+                    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+                );
+
+                CREATE TABLE IF NOT EXISTS improvement_proposals (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    agent_instance_id INTEGER REFERENCES agent_instances(id) ON DELETE CASCADE,
+                    proposal_type TEXT NOT NULL,
+                    summary TEXT NOT NULL,
+                    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+                );
+                """
+            )
+
+    def reset(self) -> None:
+        """Drop user data while keeping the schema intact (used in tests)."""
+
+        with self.session() as conn:
+            conn.executescript(
+                """
+                DELETE FROM improvement_proposals;
+                DELETE FROM agent_instances;
+                DELETE FROM function_registry;
+                DELETE FROM tool_registry;
+                DELETE FROM agent_templates;
+                """
+            )

--- a/backend/app/dynamic.py
+++ b/backend/app/dynamic.py
@@ -1,0 +1,81 @@
+"""Offline dynamic component generation stubs."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Any
+
+from .registry import RegistryService
+
+
+@dataclass(slots=True)
+class GeneratedComponent:
+    name: str
+    implementation_code: str
+    metadata: dict[str, Any]
+
+
+class DynamicBuilder:
+    """Generates deterministic mock components to simulate GPT output."""
+
+    def __init__(self, registry: RegistryService | None = None) -> None:
+        self.registry = registry or RegistryService()
+
+    async def generate_tool(self, description: str, context: dict[str, Any] | None = None) -> GeneratedComponent:
+        context = context or {}
+        name = _slugify(description, prefix="Tool")
+        code = f"def handle(payload):\n    \"\"\"Auto-generated tool for {description}.\"\"\"\n    return {{'summary': '{description}', 'payload': payload}}\n"
+        metadata = {"kind": "tool", "context": context}
+        return GeneratedComponent(name=name, implementation_code=code, metadata=metadata)
+
+    async def generate_agent(
+        self,
+        description: str,
+        capabilities: list[str] | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> GeneratedComponent:
+        context = context or {}
+        capabilities = capabilities or []
+        name = _slugify(description, prefix="Agent")
+        code = "\n".join(
+            [
+                "class AutoAgent:",
+                "    \"\"\"Auto-generated agent class.\"\"\"",
+                "    def __init__(self):",
+                f"        self.capabilities = {capabilities}",
+                "",
+                "    def respond(self, message: str) -> str:",
+                "        return f'[{name}] {message}'",
+            ]
+        )
+        metadata = {"kind": "agent", "context": context, "capabilities": capabilities}
+        return GeneratedComponent(name=name, implementation_code=code, metadata=metadata)
+
+    async def generate_function(
+        self,
+        description: str,
+        examples: list[str] | None = None,
+    ) -> GeneratedComponent:
+        examples = examples or []
+        name = _slugify(description, prefix="Function")
+        body_lines = ["def auto_function(input_value):", f"    \"\"\"{description}.\"\"\""]
+        if examples:
+            body_lines.append(f"    # Examples: {'; '.join(examples)}")
+        body_lines.append("    return {'description': input_value}")
+        code = "\n".join(body_lines)
+        metadata = {"kind": "function", "examples": examples}
+        return GeneratedComponent(name=name, implementation_code=code, metadata=metadata)
+
+    async def validate_and_test(self, component: GeneratedComponent) -> dict[str, Any]:
+        """Pretend to validate generated code by hashing its contents."""
+
+        digest = hashlib.sha256(component.implementation_code.encode()).hexdigest()
+        return {"status": "passed", "digest": digest}
+
+
+def _slugify(text: str, prefix: str) -> str:
+    normalized = "".join(ch if ch.isalnum() else " " for ch in text).strip()
+    words = normalized.split()
+    slug = "".join(word.capitalize() for word in words) or "Component"
+    return f"{prefix}{slug}"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,51 @@
+"""CLI launcher for the backend API with optional demo seeding."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import uvicorn
+
+from .api import Application
+
+
+async def seed_demo_data(app: Application) -> dict[str, Any]:
+    """Populate the database with a minimal scenario for local testing."""
+
+    app.registry.db.reset()
+    template = app.create_template(name="Planner", description="Helps plan tasks")
+    tool = app.create_tool(name="Echo", description="Echo user input")
+    function = app.create_function(name="Summarize", description="Summaries")
+    agent_id = app.deploy_agent(
+        template_id=template.id,
+        name="PlannerInstance",
+        owner_id="demo",
+        assigned_tools=[tool.id],
+        assigned_functions=[function.id],
+    )
+    route_result = app.route_request(user_input="plan my day", owner_id="demo")
+    improvement = await app.self_improve(owner_id="demo")
+    return {
+        "template": template,
+        "tool": tool,
+        "function": function,
+        "agent_id": agent_id,
+        "route_result": route_result,
+        "improvement": improvement,
+    }
+
+
+def main() -> None:
+    application = Application()
+
+    results = asyncio.run(seed_demo_data(application))
+    print("Seeded data:")
+    for key, value in results.items():
+        print(f"- {key}: {value}")
+
+    uvicorn.run(application.api, host="0.0.0.0", port=8000)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,76 @@
+"""Dataclasses representing registry records for the agent platform."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Mapping, Sequence
+
+
+@dataclass(slots=True)
+class AgentTemplate:
+    id: int
+    name: str
+    category: str
+    description: str
+    instructions_template: str
+    model_config: Mapping[str, Any]
+    required_tools: Sequence[str]
+    sample_interactions: Sequence[Mapping[str, Any]]
+    performance_metrics: Mapping[str, Any]
+    created_by: str
+    created_at: datetime
+    version: int
+
+
+@dataclass(slots=True)
+class Tool:
+    id: int
+    name: str
+    category: str
+    description: str
+    input_schema: Mapping[str, Any]
+    implementation_code: str
+    dependencies: Sequence[str]
+    test_cases: Sequence[Mapping[str, Any]]
+    performance_data: Mapping[str, Any]
+    created_by: str
+    created_at: datetime
+    version: int
+
+
+@dataclass(slots=True)
+class Function:
+    id: int
+    name: str
+    category: str
+    description: str
+    parameters_schema: Mapping[str, Any]
+    implementation_code: str
+    dependencies: Sequence[str]
+    test_cases: Sequence[Mapping[str, Any]]
+    created_by: str
+    created_at: datetime
+    version: int
+
+
+@dataclass(slots=True)
+class AgentInstance:
+    id: int
+    name: str
+    template_id: int
+    custom_instructions: str
+    assigned_tools: Sequence[int]
+    assigned_functions: Sequence[int]
+    status: str
+    owner_id: str | None
+    created_at: datetime
+
+
+@dataclass(slots=True)
+class ImprovementProposal:
+    id: int
+    agent_instance_id: int | None
+    proposal_type: str
+    summary: str
+    created_at: datetime

--- a/backend/app/orchestration.py
+++ b/backend/app/orchestration.py
@@ -1,0 +1,91 @@
+"""Agent orchestration and self-improvement workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .dynamic import DynamicBuilder
+from .registry import RegistryService
+
+
+@dataclass(slots=True)
+class RouteResult:
+    agent_instance_id: int
+    selected_tool_ids: list[int]
+    response: str
+
+
+class OrchestrationEngine:
+    """High-level coordinator that deploys agents and drives improvements."""
+
+    def __init__(self, registry: RegistryService | None = None, builder: DynamicBuilder | None = None) -> None:
+        self.registry = registry or RegistryService()
+        self.builder = builder or DynamicBuilder(registry=self.registry)
+
+    def deploy_agent(
+        self,
+        *,
+        template_id: int,
+        name: str,
+        custom_instructions: str | None = None,
+        assigned_tools: list[int] | None = None,
+        assigned_functions: list[int] | None = None,
+        status: str = "active",
+        owner_id: str | None = None,
+    ) -> int:
+        instance = self.registry.create_agent_instance(
+            name=name,
+            template_id=template_id,
+            custom_instructions=custom_instructions or "",
+            assigned_tools=assigned_tools or [],
+            assigned_functions=assigned_functions or [],
+            status=status,
+            owner_id=owner_id,
+        )
+        return instance.id
+
+    def route_request(self, *, user_input: str, owner_id: str | None = None) -> RouteResult:
+        instances = self.registry.list_agent_instances(owner_id=owner_id)
+        if not instances:
+            raise ValueError("No agent instances available for routing")
+
+        # Select the instance with the longest matching keyword (simple heuristic)
+        selected = max(
+            instances,
+            key=lambda inst: _match_score(inst, user_input),
+        )
+        tool_ids = list(selected.assigned_tools)
+        response = f"{selected.name} handled: {user_input}"
+        return RouteResult(agent_instance_id=selected.id, selected_tool_ids=tool_ids, response=response)
+
+    async def self_improve(self, owner_id: str | None = None) -> dict[str, Any]:
+        instances = self.registry.list_agent_instances(owner_id=owner_id)
+        if not instances:
+            component = await self.builder.generate_agent("fallback assistant", ["answer"], {})
+            proposal = self.registry.record_improvement(
+                agent_instance_id=None,
+                proposal_type="agent",
+                summary=f"Suggest creating {component.name}",
+            )
+            return {"proposals": [proposal.summary], "generated": component.metadata}
+
+        instance = instances[0]
+        description = f"improve {instance.name}"
+        component = await self.builder.generate_tool(description, {"instance": instance.id})
+        proposal = self.registry.record_improvement(
+            agent_instance_id=instance.id,
+            proposal_type="tool",
+            summary=f"Add tool {component.name} to agent {instance.name}",
+        )
+        validation = await self.builder.validate_and_test(component)
+        return {
+            "proposals": [proposal.summary],
+            "generated": component.metadata,
+            "validation": validation,
+        }
+
+
+def _match_score(instance, user_input: str) -> int:
+    keywords = [instance.name.lower(), instance.status.lower()] + [str(t) for t in instance.assigned_tools]
+    return max((len(word) for word in keywords if word in user_input.lower()), default=0)

--- a/backend/app/registry.py
+++ b/backend/app/registry.py
@@ -1,0 +1,316 @@
+"""Registry service built on top of the SQLite database."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Any, Sequence
+
+from .database import Database
+from .models import AgentInstance, AgentTemplate, Function, ImprovementProposal, Tool
+
+JsonLike = dict[str, Any] | list[Any]
+
+
+class RegistryService:
+    """CRUD layer for templates, tools, functions, and agent instances."""
+
+    def __init__(self, db: Database | None = None) -> None:
+        self.db = db or Database()
+
+    # Template operations -----------------------------------------------------------------
+    def create_agent_template(
+        self,
+        *,
+        name: str,
+        description: str,
+        category: str = "general",
+        instructions_template: str = "",
+        model_config: JsonLike | None = None,
+        required_tools: Sequence[str] | None = None,
+        sample_interactions: Sequence[JsonLike] | None = None,
+        performance_metrics: JsonLike | None = None,
+        created_by: str = "system",
+    ) -> AgentTemplate:
+        with self.db.session() as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO agent_templates (
+                    name, category, description, instructions_template, model_config,
+                    required_tools, sample_interactions, performance_metrics, created_by
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    name,
+                    category,
+                    description,
+                    instructions_template,
+                    json.dumps(model_config or {}),
+                    json.dumps(list(required_tools or [])),
+                    json.dumps(list(sample_interactions or [])),
+                    json.dumps(performance_metrics or {}),
+                    created_by,
+                ),
+            )
+            template_id = cursor.lastrowid
+            row = conn.execute(
+                "SELECT * FROM agent_templates WHERE id = ?",
+                (template_id,),
+            ).fetchone()
+        return self._row_to_template(row)
+
+    def list_agent_templates(self) -> list[AgentTemplate]:
+        with self.db.session() as conn:
+            rows = conn.execute("SELECT * FROM agent_templates ORDER BY id").fetchall()
+        return [self._row_to_template(row) for row in rows]
+
+    def get_agent_template(self, template_id: int) -> AgentTemplate | None:
+        with self.db.session() as conn:
+            row = conn.execute("SELECT * FROM agent_templates WHERE id = ?", (template_id,)).fetchone()
+        return self._row_to_template(row) if row else None
+
+    # Tool operations ---------------------------------------------------------------------
+    def create_tool(
+        self,
+        *,
+        name: str,
+        description: str,
+        category: str = "general",
+        input_schema: JsonLike | None = None,
+        implementation_code: str = "",
+        dependencies: Sequence[str] | None = None,
+        test_cases: Sequence[JsonLike] | None = None,
+        performance_data: JsonLike | None = None,
+        created_by: str = "system",
+    ) -> Tool:
+        with self.db.session() as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO tool_registry (
+                    name, category, description, input_schema, implementation_code,
+                    dependencies, test_cases, performance_data, created_by
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    name,
+                    category,
+                    description,
+                    json.dumps(input_schema or {}),
+                    implementation_code,
+                    json.dumps(list(dependencies or [])),
+                    json.dumps(list(test_cases or [])),
+                    json.dumps(performance_data or {}),
+                    created_by,
+                ),
+            )
+            tool_id = cursor.lastrowid
+            row = conn.execute("SELECT * FROM tool_registry WHERE id = ?", (tool_id,)).fetchone()
+        return self._row_to_tool(row)
+
+    def list_tools(self) -> list[Tool]:
+        with self.db.session() as conn:
+            rows = conn.execute("SELECT * FROM tool_registry ORDER BY id").fetchall()
+        return [self._row_to_tool(row) for row in rows]
+
+    # Function operations -----------------------------------------------------------------
+    def create_function(
+        self,
+        *,
+        name: str,
+        description: str,
+        category: str = "general",
+        parameters_schema: JsonLike | None = None,
+        implementation_code: str = "",
+        dependencies: Sequence[str] | None = None,
+        test_cases: Sequence[JsonLike] | None = None,
+        created_by: str = "system",
+    ) -> Function:
+        with self.db.session() as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO function_registry (
+                    name, category, description, parameters_schema, implementation_code,
+                    dependencies, test_cases, created_by
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    name,
+                    category,
+                    description,
+                    json.dumps(parameters_schema or {}),
+                    implementation_code,
+                    json.dumps(list(dependencies or [])),
+                    json.dumps(list(test_cases or [])),
+                    created_by,
+                ),
+            )
+            function_id = cursor.lastrowid
+            row = conn.execute("SELECT * FROM function_registry WHERE id = ?", (function_id,)).fetchone()
+        return self._row_to_function(row)
+
+    def list_functions(self) -> list[Function]:
+        with self.db.session() as conn:
+            rows = conn.execute("SELECT * FROM function_registry ORDER BY id").fetchall()
+        return [self._row_to_function(row) for row in rows]
+
+    # Agent instances ---------------------------------------------------------------------
+    def create_agent_instance(
+        self,
+        *,
+        name: str,
+        template_id: int,
+        custom_instructions: str = "",
+        assigned_tools: Sequence[int] | None = None,
+        assigned_functions: Sequence[int] | None = None,
+        status: str = "active",
+        owner_id: str | None = None,
+    ) -> AgentInstance:
+        with self.db.session() as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO agent_instances (
+                    name, template_id, custom_instructions, assigned_tools,
+                    assigned_functions, status, owner_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    name,
+                    template_id,
+                    custom_instructions,
+                    json.dumps(list(assigned_tools or [])),
+                    json.dumps(list(assigned_functions or [])),
+                    status,
+                    owner_id,
+                ),
+            )
+            instance_id = cursor.lastrowid
+            row = conn.execute("SELECT * FROM agent_instances WHERE id = ?", (instance_id,)).fetchone()
+        return self._row_to_instance(row)
+
+    def list_agent_instances(self, owner_id: str | None = None) -> list[AgentInstance]:
+        query = "SELECT * FROM agent_instances"
+        params: list[Any] = []
+        if owner_id:
+            query += " WHERE owner_id = ?"
+            params.append(owner_id)
+        query += " ORDER BY id"
+        with self.db.session() as conn:
+            rows = conn.execute(query, params).fetchall()
+        return [self._row_to_instance(row) for row in rows]
+
+    def get_agent_instance(self, instance_id: int) -> AgentInstance | None:
+        with self.db.session() as conn:
+            row = conn.execute("SELECT * FROM agent_instances WHERE id = ?", (instance_id,)).fetchone()
+        return self._row_to_instance(row) if row else None
+
+    def record_improvement(
+        self,
+        *,
+        agent_instance_id: int | None,
+        proposal_type: str,
+        summary: str,
+    ) -> ImprovementProposal:
+        with self.db.session() as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO improvement_proposals (agent_instance_id, proposal_type, summary)
+                VALUES (?, ?, ?)
+                """,
+                (agent_instance_id, proposal_type, summary),
+            )
+            proposal_id = cursor.lastrowid
+            row = conn.execute(
+                "SELECT * FROM improvement_proposals WHERE id = ?",
+                (proposal_id,),
+            ).fetchone()
+        return self._row_to_proposal(row)
+
+    def list_improvements(self, agent_instance_id: int | None = None) -> list[ImprovementProposal]:
+        query = "SELECT * FROM improvement_proposals"
+        params: list[Any] = []
+        if agent_instance_id is not None:
+            query += " WHERE agent_instance_id = ?"
+            params.append(agent_instance_id)
+        query += " ORDER BY id"
+        with self.db.session() as conn:
+            rows = conn.execute(query, params).fetchall()
+        return [self._row_to_proposal(row) for row in rows]
+
+    # Conversion helpers ------------------------------------------------------------------
+    def _row_to_template(self, row: Any) -> AgentTemplate:
+        data = dict(row)
+        return AgentTemplate(
+            id=data["id"],
+            name=data["name"],
+            category=data["category"],
+            description=data["description"],
+            instructions_template=data["instructions_template"],
+            model_config=json.loads(data["model_config"] or "{}"),
+            required_tools=json.loads(data["required_tools"] or "[]"),
+            sample_interactions=json.loads(data["sample_interactions"] or "[]"),
+            performance_metrics=json.loads(data["performance_metrics"] or "{}"),
+            created_by=data["created_by"],
+            created_at=_to_datetime(data["created_at"]),
+            version=data["version"],
+        )
+
+    def _row_to_tool(self, row: Any) -> Tool:
+        data = dict(row)
+        return Tool(
+            id=data["id"],
+            name=data["name"],
+            category=data["category"],
+            description=data["description"],
+            input_schema=json.loads(data["input_schema"] or "{}"),
+            implementation_code=data["implementation_code"],
+            dependencies=json.loads(data["dependencies"] or "[]"),
+            test_cases=json.loads(data["test_cases"] or "[]"),
+            performance_data=json.loads(data["performance_data"] or "{}"),
+            created_by=data["created_by"],
+            created_at=_to_datetime(data["created_at"]),
+            version=data["version"],
+        )
+
+    def _row_to_function(self, row: Any) -> Function:
+        data = dict(row)
+        return Function(
+            id=data["id"],
+            name=data["name"],
+            category=data["category"],
+            description=data["description"],
+            parameters_schema=json.loads(data["parameters_schema"] or "{}"),
+            implementation_code=data["implementation_code"],
+            dependencies=json.loads(data["dependencies"] or "[]"),
+            test_cases=json.loads(data["test_cases"] or "[]"),
+            created_by=data["created_by"],
+            created_at=_to_datetime(data["created_at"]),
+            version=data["version"],
+        )
+
+    def _row_to_instance(self, row: Any) -> AgentInstance:
+        data = dict(row)
+        return AgentInstance(
+            id=data["id"],
+            name=data["name"],
+            template_id=data["template_id"],
+            custom_instructions=data["custom_instructions"],
+            assigned_tools=json.loads(data["assigned_tools"] or "[]"),
+            assigned_functions=json.loads(data["assigned_functions"] or "[]"),
+            status=data["status"],
+            owner_id=data["owner_id"],
+            created_at=_to_datetime(data["created_at"]),
+        )
+
+    def _row_to_proposal(self, row: Any) -> ImprovementProposal:
+        data = dict(row)
+        return ImprovementProposal(
+            id=data["id"],
+            agent_instance_id=data["agent_instance_id"],
+            proposal_type=data["proposal_type"],
+            summary=data["summary"],
+            created_at=_to_datetime(data["created_at"]),
+        )
+
+
+def _to_datetime(value: str) -> datetime:
+    return datetime.fromisoformat(value)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,148 @@
+"""Shared request/response schemas for the HTTP API and service layer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, List
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+# ---------------------------------------------------------------------------
+# Dataclass helpers used by the dynamic generation stubs
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class GenerationRequest:
+    kind: str
+    description: str
+    context: dict[str, Any]
+
+
+@dataclass(slots=True)
+class GenerationResponse:
+    name: str
+    code: str
+    metadata: dict[str, Any]
+
+
+@dataclass(slots=True)
+class SelfImprovementResponse:
+    proposals: list[str]
+    generated: dict[str, Any]
+    validation: dict[str, Any] | None = None
+    created_at: datetime | None = None
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models for HTTP serialization
+# ---------------------------------------------------------------------------
+
+
+class TemplateCreate(BaseModel):
+    name: str
+    description: str
+    category: str = "general"
+    instructions_template: str = ""
+    model_config: Dict[str, Any] = Field(default_factory=dict)
+    required_tools: List[str] = Field(default_factory=list)
+    sample_interactions: List[Dict[str, Any]] = Field(default_factory=list)
+    performance_metrics: Dict[str, Any] = Field(default_factory=dict)
+    created_by: str = "system"
+
+
+class TemplateRead(TemplateCreate):
+    id: int
+    created_at: datetime
+    version: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ToolCreate(BaseModel):
+    name: str
+    description: str
+    category: str = "general"
+    input_schema: Dict[str, Any] = Field(default_factory=dict)
+    implementation_code: str = ""
+    dependencies: List[str] = Field(default_factory=list)
+    test_cases: List[Dict[str, Any]] = Field(default_factory=list)
+    performance_data: Dict[str, Any] = Field(default_factory=dict)
+    created_by: str = "system"
+
+
+class ToolRead(ToolCreate):
+    id: int
+    created_at: datetime
+    version: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class FunctionCreate(BaseModel):
+    name: str
+    description: str
+    category: str = "general"
+    parameters_schema: Dict[str, Any] = Field(default_factory=dict)
+    implementation_code: str = ""
+    dependencies: List[str] = Field(default_factory=list)
+    test_cases: List[Dict[str, Any]] = Field(default_factory=list)
+    created_by: str = "system"
+
+
+class FunctionRead(FunctionCreate):
+    id: int
+    created_at: datetime
+    version: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AgentDeployRequest(BaseModel):
+    template_id: int
+    name: str
+    custom_instructions: str | None = None
+    assigned_tools: List[int] | None = None
+    assigned_functions: List[int] | None = None
+    owner_id: str | None = None
+
+
+class AgentRead(BaseModel):
+    id: int
+    template_id: int
+    name: str
+    custom_instructions: str
+    assigned_tools: List[int]
+    assigned_functions: List[int]
+    status: str
+    owner_id: str | None = None
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AgentDeployResponse(AgentRead):
+    """Response payload for agent deployment operations."""
+
+
+class RouteRequest(BaseModel):
+    user_input: str
+    owner_id: str | None = None
+
+
+class RouteResponse(BaseModel):
+    agent_instance_id: int
+    selected_tool_ids: List[int]
+    response: str
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class SelfImproveResponse(BaseModel):
+    proposals: List[str]
+    generated: Dict[str, Any]
+    validation: Dict[str, Any] | None = None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "dynamic-agent-platform"
+version = "0.3.0"
+description = "Backend services for the dynamic AI agent platform"
+authors = [{name = "OpenAI Agent"}]
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi>=0.110,<1",
+    "pydantic>=2.6",
+    "uvicorn[standard]>=0.29,<1",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.1",
+]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -1,0 +1,105 @@
+"""Unit tests for the backend service and HTTP layers."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+import sys
+
+from fastapi.testclient import TestClient
+
+SYS_PATH = Path(__file__).resolve().parents[1]
+if str(SYS_PATH) not in sys.path:
+    sys.path.insert(0, str(SYS_PATH))
+
+
+from app.api import Application
+from app.database import Database
+from app.dynamic import DynamicBuilder
+from app.orchestration import OrchestrationEngine
+from app.registry import RegistryService
+
+
+def test_registry_and_routing(tmp_path):
+    db_path = tmp_path / "agent.db"
+    registry = RegistryService(Database(db_path))
+    registry.db.reset()
+
+    template = registry.create_agent_template(name="Planner", description="Helps plan")
+    tool = registry.create_tool(name="Echo", description="Echo input")
+    function = registry.create_function(name="Summarize", description="Summaries")
+
+    instance = registry.create_agent_instance(
+        name="PlannerInstance",
+        template_id=template.id,
+        assigned_tools=[tool.id],
+        assigned_functions=[function.id],
+        owner_id="user-1",
+    )
+
+    engine = OrchestrationEngine(registry=registry)
+    result = engine.route_request(user_input="please plan my day", owner_id="user-1")
+
+    assert result.agent_instance_id == instance.id
+    assert result.selected_tool_ids == [tool.id]
+    assert "PlannerInstance" in result.response
+
+
+def test_self_improvement_records_proposals(tmp_path):
+    db_path = tmp_path / "agent.db"
+    registry = RegistryService(Database(db_path))
+    registry.db.reset()
+
+    template = registry.create_agent_template(name="Helper", description="Helps")
+    registry.create_agent_instance(name="HelperInstance", template_id=template.id, owner_id="owner")
+
+    engine = OrchestrationEngine(registry=registry)
+    result = asyncio.run(engine.self_improve(owner_id="owner"))
+
+    assert result["proposals"], result
+    proposals = registry.list_improvements()
+    assert proposals[0].summary == result["proposals"][0]
+
+
+def test_dynamic_builder_determinism(tmp_path):
+    registry = RegistryService(Database(tmp_path / "agent.db"))
+    registry.db.reset()
+    builder = DynamicBuilder(registry=registry)
+
+    component = asyncio.run(builder.generate_tool("summarize incidents", {"priority": "high"}))
+    validation = asyncio.run(builder.validate_and_test(component))
+
+    assert component.metadata["kind"] == "tool"
+    assert validation["status"] == "passed"
+    digest = validation["digest"]
+
+    component_again = asyncio.run(builder.generate_tool("summarize incidents", {"priority": "high"}))
+    validation_again = asyncio.run(builder.validate_and_test(component_again))
+    assert validation_again["digest"] == digest
+
+
+def test_http_endpoints(tmp_path):
+    db = Database(tmp_path / "agent.db")
+    app = Application(RegistryService(db))
+    client = TestClient(app.api)
+
+    template_payload = {"name": "Planner", "description": "Helps plan"}
+    response = client.post("/templates", json=template_payload)
+    assert response.status_code == 201, response.text
+    template_id = response.json()["id"]
+
+    tool_payload = {"name": "Echo", "description": "Echo input"}
+    tool_response = client.post("/tools", json=tool_payload)
+    assert tool_response.status_code == 201
+
+    deploy_payload = {"template_id": template_id, "name": "PlannerInstance", "owner_id": "user"}
+    deploy_response = client.post("/agents/deploy", json=deploy_payload)
+    assert deploy_response.status_code == 201
+
+    route_response = client.post("/route", json={"user_input": "plan", "owner_id": "user"})
+    assert route_response.status_code == 200
+    assert route_response.json()["agent_instance_id"] == deploy_response.json()["id"]
+
+    improve_response = client.post("/self-improve", params={"owner_id": "user"})
+    assert improve_response.status_code == 200
+    assert improve_response.json()["proposals"], improve_response.json()

--- a/docs/action_plan.md
+++ b/docs/action_plan.md
@@ -1,0 +1,26 @@
+# Implementation Action Plan
+
+This action plan breaks the dynamic agent platform into iterative milestones so we can deliver a working foundation before layering on advanced capabilities.
+
+## Phase 0 – Project Bootstrap (This Commit)
+- Define a lightweight Python backend package that does not depend on heavy third‑party frameworks so it can run inside the sandbox.
+- Introduce a SQLite schema plus data-access helpers for templates, tools, functions, and agent instances.
+- Implement service-layer primitives for the registry, dynamic code generation stubs, and orchestration flows.
+- Cover the new behavior with unit tests that exercise registry CRUD, orchestration, and the simulated self-improvement loop.
+
+## Phase 1 – Persistence and Registry Enhancements
+- Add migration utilities and fixture loaders for seeding default templates and tools.
+- Implement query filtering (by category, owner, status) and pagination helpers.
+- Record performance metrics and usage statistics per component.
+
+## Phase 2 – Self-Improvement & Analytics
+- Expand the dynamic builder to score generated components with rule-based validators and historical performance data.
+- Persist evaluation artifacts (e.g., sandbox test runs) and expose summary analytics from the orchestration engine.
+- Introduce feedback ingestion interfaces so user scores influence auto-improvement decisions.
+
+## Phase 3 – Interface & Integration Surface
+- Wrap the service layer with a REST API (or CLI) once FastAPI/HTTP dependencies are available.
+- Provide a reference integration script that demonstrates composing agents and handling routed conversations.
+- Document the API contract and release OpenAPI/CLI usage examples.
+
+Each phase can ship independently while gradually converging on the full dynamic agent platform described in the implementation specification.

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -1,0 +1,223 @@
+# Dynamic AI Agent Platform — Architecture Overview
+
+## Purpose
+This document translates the product vision and implementation specification into a concrete, end-to-end architecture blueprint. It clarifies system boundaries, primary data flows, and the responsibilities of each subsystem so engineering teams can deliver the platform iteratively without losing sight of the long-term goal of fully autonomous, self-improving agents.
+
+## High-Level System Diagram (Textual)
+```
+┌────────────────────────┐       ┌────────────────────────┐
+│        Frontend        │       │        Backends         │
+│                        │       │                        │
+│ • Meta-Management UI   │◀──────▶ Registry Service       │
+│ • Interactive Agent UI │       │ • Persistence Layer     │
+│ • Self-Service Builder │       │ • Dynamic Code Builder  │
+│                        │       │ • Orchestration Engine  │
+└────────────────────────┘       │ • Monitoring Pipeline   │
+        ▲        ▲               │ • Meta-Agent Controller │
+        │        │               └────────────────────────┘
+        │        │                         │
+        │        └───────────────┐         ▼
+        │                        ▼  ┌────────────────────────┐
+        │                 ┌────────▶│   Agent Runtime Mesh   │
+        │                 │        │ • Root Conversational  │
+        │                 │        │ • Domain Sub-Agents     │
+        │                 │        │ • Function Tools        │
+        │                 │        └────────────────────────┘
+        │                 │                 │
+        ▼                 │                 ▼
+┌────────────────────────┐│        ┌────────────────────────┐
+│    Shared Services     │└────────▶ Memory & Feedback Layer│
+│ • Message Bus / Queue  │         │ • Vector + SQL Stores  │
+│ • Feature Flags        │         │ • Event Streams        │
+│ • Sandbox Execution    │         │ • Evaluation Signals   │
+└────────────────────────┘         └────────────────────────┘
+```
+
+### Core Request Flow (Happy Path)
+1. **User Interaction** → Message hits API Gateway (REST/WebSocket) and authenticates.
+2. **Session Orchestration** → Gateway forwards payload to the Orchestration Engine which resolves the active agent graph.
+3. **Context Retrieval** → Orchestration queries the Memory Layer (vector + SQL) for relevant state and augments the prompt.
+4. **Agent Execution** → Root agent handles the turn or dispatches to a sub-agent/function tool; tools may call external APIs.
+5. **Response Delivery** → Result returns to Orchestration, is logged to Monitoring + Memory, and streamed back to the frontend.
+6. **Continuous Learning** → Meta-agent inspects telemetry events asynchronously and may queue improvements.
+
+## Backend Services
+
+### 1. Registry Service
+* **Purpose**: Acts as the system-of-record for every agent template, deployed instance, tool, and function.
+* **Technology**: PostgreSQL (relational schema per `implementation_spec.md`) + Prisma ORM or SQLAlchemy for type-safe access.
+* **Key Responsibilities**:
+  - Versioned storage and diffing of agent templates and generated assets.
+  - Cohort-aware releases to support canary deployments and rollback.
+  - Change-feed publishing (via Postgres logical replication or CDC) to notify other services of new/updated resources.
+* **APIs**:
+  - `POST /templates` create new agent/tool/function templates with validation hooks.
+  - `GET /templates/:id?version=` fetch versioned configuration bundles for the Agent Builder.
+  - `POST /releases` publish version changes along with rollout cohort metadata.
+* **Scaling Considerations**: Use read replicas for analytical workloads, partition large audit tables by time, and enable row-level security for multi-tenant isolation.
+
+### 2. Dynamic Code Generation Service
+* **Purpose**: Wraps GPT-5 and orchestrates speculative generation of tools, functions, and agent templates.
+* **Key Responsibilities**:
+  - Retrieve relevant examples/instructions from the registry and memory layer to prime generation prompts.
+  - Execute generated artifacts inside a sandbox (e.g., Firecracker microVM, Docker-in-Docker) with restricted capabilities.
+  - Persist validated artifacts and attach metadata (tests, dependencies, provenance).
+  - Integrate with policy and safety checks before promoting assets to the registry.
+* **Detailed Workflow**:
+  1. Receive generation request (user-driven or meta-agent triggered) with natural language requirements.
+  2. Retrieve precedents (similar tools, domain policies) using hybrid search across vector + relational stores.
+  3. Construct guarded prompt with spec, coding conventions, and required tests.
+  4. Stream GPT-5 output to sandbox workspace, execute linting/unit tests, and capture traces.
+  5. Run automated red-teaming (prompt-injection, safety classifiers) before packaging artifact.
+  6. Submit bundle to Registry via signed service account with provenance data.
+* **Interfaces**: gRPC service for low-latency orchestration calls, async job queue (Kafka topic) for longer-running generation batches.
+* **Observability**: Emit structured events for each pipeline stage to support step-level latency monitoring and automatic retries.
+
+### 3. Orchestration Engine
+* **Purpose**: Materializes runtime agent graphs from configuration, handles routing, and supervises agent lifecycles.
+* **Key Responsibilities**:
+  - Compose the root agent, sub-agents, and tool chain from the registry via the Agent Builder.
+  - Maintain session context and manage hand-offs between agents.
+  - Surface execution traces and metrics to the monitoring pipeline.
+  - Provide APIs for hot-swapping agents after successful canary evaluation.
+* **Runtime Architecture**:
+  - **Session Manager**: Maintains active conversations, resolves user entitlements, and coordinates streaming responses.
+  - **Agent Builder**: Deterministically constructs agent graphs from registry bundles and applies feature-flag overrides.
+  - **Router**: Implements policy-driven dispatch (LLM-powered router + deterministic rules) for sub-agent selection.
+  - **Execution Supervisor**: Tracks tool calls, enforces rate limits, and handles failure recovery (fallback agents, human escalation).
+* **Resilience Strategy**: Deploy as stateless services behind a load balancer, persist session checkpoints in Redis/Postgres, and support blue/green upgrades for agent graphs.
+
+### 4. Performance Monitoring & Analytics
+* **Purpose**: Provide real-time and historical insights for both humans and the meta-agent.
+* **Implementation Sketch**:
+  - Telemetry ingestion with OpenTelemetry or custom event schema streamed to Kafka/Pulsar.
+  - Metrics aggregation with ClickHouse or TimescaleDB.
+  - Alerting hooks back into Orchestration and Meta-Agent for automated remediation.
+* **Dashboards & Consumers**:
+  - Real-time SLO dashboards (latency, success rate, cost per interaction).
+  - Meta-agent evaluation jobs that combine telemetry with qualitative feedback to score agent variants.
+  - Governance reporting for compliance teams (audit trails, change history).
+
+## Frontend Surfaces
+
+### Meta-Management Dashboard
+* Built with Next.js + TypeScript, Tailwind CSS, and React Query.
+* Exposes registry browsers, template editors, analytics dashboards, and audit logs.
+* Subscribes to registry change-feed to live-update listings and highlight canary promotions/rollbacks.
+* **Key Views**:
+  - **Configuration Explorer**: Nested view of agent graphs, tools, and version metadata with diff visualizations.
+  - **Rollout Center**: Launch, monitor, and rollback releases with live cohort metrics.
+  - **Governance Hub**: Review auto-generated change proposals, attach human approvals, and manage policy exceptions.
+
+### Interactive Agent Interface
+* Chat-like experience for end-users with support for attachments, voice (WebRTC), and tool invocation traces.
+* Consumes a Session API from the Orchestration Engine and renders agent responses, intermediate reasoning, and generated artifacts.
+* **Enhancements**:
+  - Offline-capable message cache for mobile clients.
+  - Inline visualization of tool outputs (tables, charts, task boards).
+  - Conversation summary drawer sourcing embeddings from the memory layer for continuity.
+
+### Self-Service Agent Builder
+* Wizard-driven interface that collects natural language requirements and invokes the Dynamic Code Generation service.
+* Provides inline previews of generated instructions, tools, and test plans before publishing to the registry.
+* **User Journey**:
+  1. Capture goal + constraints, optionally import datasets/API keys.
+  2. Preview generated prompts, tool schemas, and evaluation plan.
+  3. Run sandbox dry-run and inspect telemetry traces.
+  4. Submit for auto-approval or route to human reviewer depending on risk scoring.
+
+## Shared Infrastructure
+
+### Data Stores
+* **Relational DB**: PostgreSQL for strong consistency of configuration and audit logs.
+* **Vector Store**: pgvector, Pinecone, or Milvus for embedding-based retrieval powering personalization and meta-evaluation.
+* **Object Storage**: S3-compatible bucket for large artifacts, generated code archives, and sandbox logs.
+* **Data Governance**: Tag rows with tenant + sensitivity labels, enforce encryption at rest (KMS-managed keys), and support regional replicas for data residency.
+
+### Messaging & Events
+* Use Kafka/Pulsar for high-throughput event streaming between services.
+* Employ WebSockets/Socket.IO for real-time frontend updates.
+* **Event Taxonomy**:
+  - `telemetry.*`: Structured logs of agent/tool execution with trace IDs.
+  - `registry.change`: Version promotion, rollback, or deletion events consumed by dashboards and Orchestration.
+  - `meta_agent.action`: Proposed improvements, remediation workflows, and experiment assignments.
+
+### Sandbox & Execution
+* Firecracker- or gVisor-backed sandboxes for executing generated code safely.
+* Kubernetes manages sandbox pods with resource quotas and network policies.
+* **Security Hardening**: Enforce seccomp profiles, outbound network allow-lists, dependency caching with signature verification, and ephemeral credentials for external APIs.
+
+## Agent Graph Composition & Data Flow
+* **Version Bundles**: Registry packages templates, tool specs, and routing edges into signed bundles; Orchestration validates signatures before applying.
+* **Feature Flags**: ConfigCat or LaunchDarkly toggles enable progressive exposure of new agents to cohorts.
+* **Memory Lifecycle**:
+  - **Short-Term**: Redis/KeyDB stores turn-level context for quick retrieval.
+  - **Long-Term**: Vector DB stores embeddings with metadata; nightly jobs decay stale memories per retention policy.
+  - **Meta Signals**: Aggregated feedback stored in analytics warehouse (e.g., BigQuery/Snowflake) for trend analysis.
+* **Experimentation**: Multi-armed bandit service assigns agent variants to cohorts and reports back to meta-agent for optimization.
+
+## Security & Compliance Posture
+1. **Authentication & Authorization**: OAuth 2.0 / OIDC for end-users, mTLS + workload identity for service-to-service calls.
+2. **Secrets Management**: HashiCorp Vault or AWS Secrets Manager with dynamic credentials injected via sidecars.
+3. **Data Protection**: Encrypt all persistent storage, enforce tokenization for PII, and provide audit trails for sensitive tool usage.
+4. **Compliance Targets**: SOC2 Type II and GDPR readiness, including data subject access and deletion workflows managed through the meta-management dashboard.
+
+## Testing & Quality Gates
+* **Unit & Contract Tests**: Required for every generated artifact; stored alongside code in object storage and referenced in the registry.
+* **Sandbox Validation**: Run integration tests against mocked external APIs with coverage thresholds prior to promotion.
+* **Shadow Mode Deployments**: New agents run in observation mode capturing responses without user exposure until KPIs are met.
+* **Continuous Evaluation**: Meta-agent triggers regression suites using recorded conversations to detect drift or regressions.
+
+## Deployment & Operations
+* **Environment Layout**: Separate dev, staging, canary, and production clusters managed via GitOps (ArgoCD/Flux) with infrastructure-as-code (Terraform).
+* **CI/CD**: GitHub Actions pipelines building container images, running policy-as-code checks (OPA/Conftest), and publishing Helm charts.
+* **Scalability**: Horizontal autoscaling based on CPU/token throughput; scheduled scaling during peak usage windows.
+* **Incident Response**: On-call rotations with runbooks in the dashboard, automated rollback hooks tied to SLO breaches, and post-incident review templates.
+
+## Self-Improvement Loop Implementation
+1. **Detection**: Monitoring pipeline emits capability gap events (e.g., high failure rate for a category of requests).
+2. **Synthesis**: Dynamic Code Generation service prompts GPT-5 with usage traces + context to propose new tools/functions.
+3. **Validation**: Generated code is executed in sandbox with registry-provided test cases; additional synthetic tests are composed if missing.
+4. **Review & Governance**: Meta-agent evaluates metrics, optionally requests human approval, and version-tags the artifact.
+5. **Deployment**: Orchestration Engine pulls the new version, runs canary sessions, and promotes on success.
+6. **Feedback Integration**: Metrics and user feedback are stored, closing the loop for future iterations.
+
+## Release Strategy
+* **Weeks 1-2**: Stand up core backend services with minimal viable schemas and APIs. Provide CLI tooling for registry operations.
+* **Weeks 3-4**: Deliver admin dashboard MVP with template browsing/editing and real-time monitoring widgets.
+* **Weeks 5-6**: Launch end-user chat interface and agent builder flow backed by orchestration APIs.
+* **Weeks 7-8**: Integrate autonomous generation pipeline and sandbox testing for self-improvement features.
+* **Weeks 9-10**: Harden platform with auth, multi-tenancy, SLAs, and optimization features (caching, cost controls).
+
+## Implementation Milestones & Dependencies
+| Milestone | Key Deliverables | Dependencies |
+|-----------|------------------|--------------|
+| M1: Registry Foundations | Schema migrations, CRUD APIs, change-feed emitter | PostgreSQL cluster provisioned |
+| M2: Orchestration MVP | Agent Builder, session manager, baseline routing | Registry M1, Memory bootstrap |
+| M3: Frontend Admin Beta | Config explorer, rollout center, audit logs | Orchestration APIs, change-feed |
+| M4: Generation Pipeline | Sandbox infra, automated validation, policy checks | Object storage, monitoring |
+| M5: Self-Improvement Alpha | Meta-agent heuristics, experimentation service | Monitoring telemetry, generation pipeline |
+| M6: Production Hardening | AuthN/Z, compliance workflows, scaling | Prior milestones |
+
+## Open Risks & Mitigations
+1. **Model Dependency on GPT-5**: Maintain adapters for alternate LLMs (GPT-4.1, Anthropic) and cache validated tools to reduce regeneration frequency.
+2. **Automated Tool Misbehavior**: Enforce scoped API keys, human review thresholds, and kill-switches per tool category.
+3. **Data Drift**: Implement automated drift detection comparing live telemetry with historical baselines; trigger retraining or reconfiguration workflows.
+4. **Cost Overruns**: Track per-agent cost metrics and allow meta-agent to throttle or retire low ROI capabilities.
+
+## Glossary
+* **Agent Bundle** – Signed package containing agent instructions, tool schemas, routing policies, and evaluation metadata.
+* **Meta-Agent** – Supervisory service analyzing telemetry to propose configuration updates and orchestrate experiments.
+* **Sandbox Workspace** – Ephemeral execution environment used for validating generated code and running tests.
+* **Capability Gap Event** – Structured alert indicating underperformance or unmet user needs triggering the self-improvement loop.
+
+## Open Questions & Next Steps
+1. **GPT-5 Access**: Confirm latency/cost expectations and fallback strategy if GPT-5 is unavailable.
+2. **Safety Guardrails**: Define policies for auto-deployed tools (permissions, human-in-the-loop thresholds).
+3. **Evaluation Metrics**: Finalize KPIs for automated acceptance (success rates, latency, hallucination scoring).
+4. **Observability**: Choose a unified telemetry stack to avoid fragmentation between services.
+5. **Data Residency**: Determine compliance requirements (PII handling, region constraints) prior to multi-tenancy work.
+
+---
+Prepared by: Engineering Architecture Team  
+Date: 2025-09-27

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,34 @@
+# Dynamic Agent Platform Frontend
+
+A lightweight dashboard that interacts with the FastAPI backend to create templates, register tools, deploy agents, and exercise the self-improvement flow.
+
+## Getting Started
+
+1. Start the backend server (see `../backend/README.md`).
+2. Serve the static frontend files. Any static server works; for example:
+
+```bash
+cd frontend
+python -m http.server 5173
+```
+
+3. Open <http://localhost:5173> in your browser.
+
+The frontend assumes the backend is available at `http://localhost:8000`. To point to a different host, open the browser console and run:
+
+```js
+localStorage.setItem('dap-api-base', 'http://your-host:port');
+location.reload();
+```
+
+## Features
+
+- Template creation with instant list updates.
+- Tool registry management.
+- Agent deployment picker tied to available templates.
+- Request routing console with live JSON responses.
+- One-click self-improvement trigger showing generated metadata.
+
+## Development Notes
+
+The UI uses vanilla JavaScript and modern CSS so no build tooling is required. Adjust `styles.css` and `app.js` as needed for custom workflows.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,202 @@
+const API_BASE = localStorage.getItem('dap-api-base') || 'http://localhost:8000';
+
+const templateForm = document.getElementById('template-form');
+const templateList = document.getElementById('template-list');
+const toolForm = document.getElementById('tool-form');
+const toolList = document.getElementById('tool-list');
+const deploymentForm = document.getElementById('deployment-form');
+const deploymentList = document.getElementById('deployment-list');
+const deploymentTemplateSelect = document.getElementById('deployment-template');
+const routeForm = document.getElementById('route-form');
+const routeOutput = document.getElementById('route-output');
+const improveButton = document.getElementById('improve-button');
+const improveOutput = document.getElementById('improve-output');
+
+const state = {
+  templates: [],
+  tools: [],
+  agents: [],
+};
+
+async function request(path, options = {}) {
+  const response = await fetch(`${API_BASE}${path}`, {
+    headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
+    ...options,
+  });
+
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(`Request failed: ${response.status} ${response.statusText}\n${detail}`);
+  }
+
+  if (response.status === 204) {
+    return null;
+  }
+
+  return response.json();
+}
+
+function renderTemplates() {
+  templateList.innerHTML = '';
+  deploymentTemplateSelect.innerHTML = '<option value="" disabled selected>Select template</option>';
+
+  state.templates.forEach((template) => {
+    const item = document.createElement('div');
+    item.className = 'list-item';
+    item.innerHTML = `<strong>${template.name}</strong><span>${template.description}</span>`;
+    templateList.appendChild(item);
+
+    const option = document.createElement('option');
+    option.value = template.id;
+    option.textContent = `${template.name} (#${template.id})`;
+    deploymentTemplateSelect.appendChild(option);
+  });
+}
+
+function renderTools() {
+  toolList.innerHTML = '';
+  state.tools.forEach((tool) => {
+    const item = document.createElement('div');
+    item.className = 'list-item';
+    item.innerHTML = `<strong>${tool.name}</strong><span>${tool.description}</span>`;
+    toolList.appendChild(item);
+  });
+}
+
+function renderAgents() {
+  deploymentList.innerHTML = '';
+  if (state.agents.length === 0) {
+    deploymentList.innerHTML = '<p>No agents deployed yet.</p>';
+    return;
+  }
+
+  state.agents.forEach((agent) => {
+    const item = document.createElement('div');
+    item.className = 'list-item';
+    const tools = agent.assigned_tools.length ? agent.assigned_tools.join(', ') : 'none';
+    item.innerHTML = `
+      <strong>${agent.name}</strong>
+      <span>Template: ${agent.template_id}</span>
+      <span>Owner: ${agent.owner_id || 'n/a'}</span>
+      <span>Tools: ${tools}</span>
+    `;
+    deploymentList.appendChild(item);
+  });
+}
+
+async function loadInitialData() {
+  try {
+    const [templates, tools, agents] = await Promise.all([
+      request('/templates'),
+      request('/tools'),
+      request('/agents'),
+    ]);
+    state.templates = templates;
+    state.tools = tools;
+    state.agents = agents;
+    renderTemplates();
+    renderTools();
+    renderAgents();
+  } catch (error) {
+    console.error(error);
+    routeOutput.textContent = error.message;
+  }
+}
+
+templateForm.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const name = document.getElementById('template-name').value.trim();
+  const description = document.getElementById('template-description').value.trim();
+  if (!name || !description) return;
+
+  try {
+    const template = await request('/templates', {
+      method: 'POST',
+      body: JSON.stringify({ name, description }),
+    });
+    state.templates.push(template);
+    renderTemplates();
+    templateForm.reset();
+  } catch (error) {
+    alert(error.message);
+  }
+});
+
+toolForm.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const name = document.getElementById('tool-name').value.trim();
+  const description = document.getElementById('tool-description').value.trim();
+  if (!name || !description) return;
+
+  try {
+    const tool = await request('/tools', {
+      method: 'POST',
+      body: JSON.stringify({ name, description }),
+    });
+    state.tools.push(tool);
+    renderTools();
+    toolForm.reset();
+  } catch (error) {
+    alert(error.message);
+  }
+});
+
+deploymentForm.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const name = document.getElementById('deployment-name').value.trim();
+  const owner = document.getElementById('deployment-owner').value.trim();
+  const templateId = deploymentTemplateSelect.value;
+  if (!name || !templateId) return;
+
+  try {
+    const payload = { name, template_id: Number(templateId) };
+    if (owner) payload.owner_id = owner;
+    const agent = await request('/agents/deploy', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+    state.agents.push(agent);
+    renderAgents();
+    deploymentForm.reset();
+    deploymentTemplateSelect.selectedIndex = 0;
+  } catch (error) {
+    alert(error.message);
+  }
+});
+
+routeForm.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const userInput = document.getElementById('route-input').value.trim();
+  const ownerId = document.getElementById('route-owner').value.trim();
+  if (!userInput) return;
+
+  try {
+    const body = { user_input: userInput };
+    if (ownerId) body.owner_id = ownerId;
+    const result = await request('/route', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+    routeOutput.textContent = JSON.stringify(result, null, 2);
+  } catch (error) {
+    routeOutput.textContent = error.message;
+  }
+});
+
+improveButton.addEventListener('click', async () => {
+  const ownerId = document.getElementById('route-owner').value.trim();
+  const params = ownerId ? `?owner_id=${encodeURIComponent(ownerId)}` : '';
+  try {
+    const result = await request(`/self-improve${params}`, { method: 'POST' });
+    improveOutput.textContent = JSON.stringify(result, null, 2);
+    if (result.generated?.context?.instance) {
+      const agents = await request('/agents');
+      state.agents = agents;
+      renderAgents();
+    }
+  } catch (error) {
+    improveOutput.textContent = error.message;
+  }
+});
+
+loadInitialData();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dynamic Agent Platform</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Dynamic Agent Platform</h1>
+      <p>Create templates, register tools, deploy agents, and trigger self-improvement from a single dashboard.</p>
+    </header>
+
+    <main>
+      <section class="card" id="templates">
+        <h2>Agent Templates</h2>
+        <form id="template-form">
+          <div class="field">
+            <label for="template-name">Name</label>
+            <input id="template-name" required />
+          </div>
+          <div class="field">
+            <label for="template-description">Description</label>
+            <textarea id="template-description" required></textarea>
+          </div>
+          <button type="submit">Create Template</button>
+        </form>
+        <div class="list" id="template-list"></div>
+      </section>
+
+      <section class="card" id="tools">
+        <h2>Tool Registry</h2>
+        <form id="tool-form">
+          <div class="field">
+            <label for="tool-name">Name</label>
+            <input id="tool-name" required />
+          </div>
+          <div class="field">
+            <label for="tool-description">Description</label>
+            <textarea id="tool-description" required></textarea>
+          </div>
+          <button type="submit">Register Tool</button>
+        </form>
+        <div class="list" id="tool-list"></div>
+      </section>
+
+      <section class="card" id="deployments">
+        <h2>Deploy Agent</h2>
+        <form id="deployment-form">
+          <div class="field">
+            <label for="deployment-name">Instance Name</label>
+            <input id="deployment-name" required />
+          </div>
+          <div class="field">
+            <label for="deployment-owner">Owner</label>
+            <input id="deployment-owner" placeholder="team-or-user" />
+          </div>
+          <div class="field">
+            <label for="deployment-template">Template</label>
+            <select id="deployment-template" required></select>
+          </div>
+          <button type="submit">Deploy</button>
+        </form>
+        <div class="list" id="deployment-list"></div>
+      </section>
+
+      <section class="card" id="router">
+        <h2>Route &amp; Self-Improve</h2>
+        <form id="route-form">
+          <div class="field">
+            <label for="route-input">User Input</label>
+            <textarea id="route-input" placeholder="Ask an agent for help" required></textarea>
+          </div>
+          <div class="field">
+            <label for="route-owner">Owner</label>
+            <input id="route-owner" placeholder="team-or-user" />
+          </div>
+          <button type="submit">Route Request</button>
+        </form>
+        <pre class="output" id="route-output">No request submitted yet.</pre>
+        <button id="improve-button" class="secondary">Trigger Self-Improvement</button>
+        <pre class="output" id="improve-output">No improvements recorded.</pre>
+      </section>
+    </main>
+
+    <footer>
+      <p>
+        Backend must run locally on <code>http://localhost:8000</code>. Update the API base URL in
+        <code>app.js</code> if your server is hosted elsewhere.
+      </p>
+    </footer>
+
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,143 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: #0d1117;
+  color: #f0f6fc;
+}
+
+body {
+  margin: 0;
+  padding: 0 1.5rem 4rem;
+  background: linear-gradient(180deg, #0d1117 0%, #161b22 100%);
+}
+
+header {
+  text-align: center;
+  padding: 2rem 0 1rem;
+}
+
+header h1 {
+  margin-bottom: 0.5rem;
+  font-size: 2.5rem;
+}
+
+main {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.card {
+  background: rgba(13, 17, 23, 0.8);
+  border: 1px solid rgba(240, 246, 252, 0.1);
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.card h2 {
+  margin: 0;
+  font-size: 1.4rem;
+  letter-spacing: 0.02em;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+input,
+textarea,
+select {
+  padding: 0.75rem;
+  border-radius: 10px;
+  border: 1px solid rgba(240, 246, 252, 0.1);
+  background: rgba(22, 27, 34, 0.85);
+  color: inherit;
+}
+
+textarea {
+  min-height: 80px;
+  resize: vertical;
+}
+
+button {
+  cursor: pointer;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: none;
+  background: linear-gradient(90deg, #2563eb 0%, #9333ea 100%);
+  color: white;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 16px rgba(37, 99, 235, 0.3);
+}
+
+button.secondary {
+  align-self: flex-start;
+  background: rgba(240, 246, 252, 0.08);
+  color: inherit;
+  box-shadow: none;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: 180px;
+  overflow-y: auto;
+}
+
+.list-item {
+  padding: 0.75rem;
+  border-radius: 12px;
+  background: rgba(22, 27, 34, 0.8);
+  border: 1px solid rgba(240, 246, 252, 0.07);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.output {
+  background: rgba(22, 27, 34, 0.8);
+  padding: 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(240, 246, 252, 0.08);
+  max-height: 160px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+}
+
+footer {
+  max-width: 900px;
+  margin: 3rem auto 0;
+  text-align: center;
+  color: rgba(240, 246, 252, 0.7);
+}
+
+@media (max-width: 640px) {
+  body {
+    padding: 0 1rem 3rem;
+  }
+
+  header h1 {
+    font-size: 2rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a FastAPI application exposing registry, deployment, routing, and self-improvement endpoints with CORS support
- seed demo data and launch uvicorn from the CLI entry point while expanding orchestration, schemas, and tests for HTTP coverage
- introduce a static HTML/CSS/JS dashboard and documentation updates for running the backend and frontend

## Testing
- `pip install -e .[dev]` *(fails: outbound package downloads blocked in sandbox)*
- `pytest` *(fails: fastapi dependency unavailable because installation is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68d77b8d76608326ba513cc388fcd5b6